### PR TITLE
v1.2 merge

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: LLVM, AlignTrailingComments: true, UseTab: Always, IndentWidth: 4, TabWidth: 4, AllowShortIfStatementsOnASingleLine: true, IndentCaseLabels: true, ColumnLimit: 120}",
     "cmake.configureSettings": {
         "CUNITTESTS_TESTING":true,
-        "CMAKE_C_FLAGS":"-Werror -Wall -Wpedantic -Wextra"
+        "CUNITTESTS_FLAGS":true,
     },
     "editor.fontSize": 18,
     "files.associations": {}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
     "C_Cpp.default.cStandard": "c11",
     "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: LLVM, AlignTrailingComments: true, UseTab: Always, IndentWidth: 4, TabWidth: 4, AllowShortIfStatementsOnASingleLine: true, IndentCaseLabels: true, ColumnLimit: 120}",
     "cmake.configureSettings": {
-        "CUNITTESTS_TESTING":true
+        "CUNITTESTS_TESTING":true,
+        "CMAKE_C_FLAGS":"-Werror -Wall -Wpedantic -Wextra"
     },
     "editor.fontSize": 18,
     "files.associations": {}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(CUnitTests INTERFACE)
 target_include_directories(CUnitTests INTERFACE include/)
 
 if(CUNITTESTS_TESTING)
-    message("${PROJECT_NAME} library testing enabled")
+    message("Adding ${PROJECT_NAME} library test executable")
     add_executable(CUnitTestsExample tests/example.c)
     target_link_libraries(CUnitTestsExample CUnitTests)
     enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
 project(CUnitTests VERSION 1.1 LANGUAGES C)
 
+if(CUNITTESTS_FLAGS)
+    message("Adding ${PROJECT_NAME} flags")
+    string(APPEND CMAKE_C_FLAGS " -Werror -Wall -Wpedantic -Wextra")
+    string(APPEND CMAKE_CXX_FLAGS " -Werror -Wall -Wpedantic -Wextra")
+endif()
+
 message("Adding ${PROJECT_NAME} library")
 add_library(CUnitTests INTERFACE)
 target_include_directories(CUnitTests INTERFACE include/)

--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@ example.c
 test(First, { printf("From test 1"); });
 ```
 
-## Tests executable
+## Tests executable usage
 ```
 program_name -e                   - execute all tests \
 program_name -ei                  - execute all tests in isolation \
 program_name -e first second ...  - execute specified tests \
 program_name -ei first second ... - execute specified tests in isolation\
 program_name                      - list all tests
+
+Additional flags:
+-c                          - color output
 ```
 The term 'in isolation' means as separate process.
 
+## Tests executable output
 Normal messages are printed to `stdout`.
 Error messages are printed to `stderr`. 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CUnitTests
 Simple and robust, single header file ANSI C unit testing library.
 
-## Defining tests
-Use the `test(TestName, {test code});` macro to add test.
+## Usage
+Include the `CUnitTests.h` library and add new test using the `test(TestName, {test code});` macro.
 
 example.c
 ``` c
@@ -23,8 +23,8 @@ test_executable                          - print usage
 
 Additional flags:
 -c                          - color output
+-q                          - quiet mode (no tests summaries)
 ```
-The term 'in isolation' means as separate process.
 
 ## Tests executable output
 Normal messages are printed to `stdout`.
@@ -58,13 +58,11 @@ test_assert_null_fmt(value, message, ...);
 test_assert_not_null(value);
 test_assert_not_null_fmt(value, message,...);
 ```
-Seting given test result from code:
-``` c
-test_set_succeed();    // changes current test result to SUCCEED.
-test_set_failed();     // changes current test result to FAILED. 
-```
+
 Additional macros:
 ``` c
+test_set_succeed();               // changes current test result to SUCCEED.
+test_set_failed();                // changes current test result to FAILED. 
 test_failed();                    // checks if given test has failed.
 test_print_info(format, args);    // prints formatted message into stdout.
 test_print_error(format, args);   // prints formatted error message into stderr.
@@ -73,12 +71,12 @@ test_print_error(format, args);   // prints formatted error message into stderr.
 example.c
 ``` c
 test(check_failure,{
+    unsigned result = 0;
     ...
-    test_assert_true(0, "Should be true");
+    test_assert_true(result);
     if(test_failed()){
         return;
     }
-    ...
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ example.c
 test(First, { printf("From test 1"); });
 ```
 
-## Tests executable usage
+## Tests executable
 ```
 program_name -e                   - execute all tests \
 program_name -ei                  - execute all tests in isolation \
@@ -20,11 +20,13 @@ program_name                      - list all tests
 ```
 The term 'in isolation' means as separate process.
 
-## Tests executable exit codes
+Normal messages are printed to `stdout`.
+Error messages are printed to `stderr`. 
+
 The test program exit codes:
 ```
 0 - Success
-1 - Test not found, Test not executed, error 
+1 - Test not found, Test not executed, Errors
 2 - Failure
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ test(First, { printf("From test 1"); });
 
 ## Tests executable usage
 ```
-program_name -e                  - execute all tests \
-program_name -ie                 - execute all tests in isolation \
-program_name -e first second ... - execute specified tests \
-program_name -i first second ... - execute specified tests in isolation\
-program_name                     - list all tests
+program_name -e                   - execute all tests \
+program_name -ei                  - execute all tests in isolation \
+program_name -e first second ...  - execute specified tests \
+program_name -ei first second ... - execute specified tests in isolation\
+program_name                      - list all tests
 ```
+The term 'in isolation' means as separate process.
 
 ## Tests executable exit codes
 The test program exit codes:
@@ -27,8 +28,8 @@ The test program exit codes:
 2 - Failure
 ```
 
-## Assertions
-Build-in assertions: 
+## API
+Build-in test assertions: 
 ``` c
 test_assert_true(expr, message, ...);				
 test_assert_false(expr, message, ...);				
@@ -37,13 +38,19 @@ test_assert_not_equal(expected, result, message, ...);
 test_assert_null(value, message, ...);
 test_assert_not_null(value, message,...);
 ```
-Use following macros to set given test result:
+Seting given test result from code:
 ``` c
-test_set_succeed(); //set current test result to Succeed.
-test_set_failed();  //set current test result to Failed. 
+test_set_succeed();    // changes current test result to Succeed.
+test_set_failed();     // changes current test result to Failed. 
 ```
-Use `test_failed()` to check if test has failed
+Additional macros:
+``` c
+test_failed();                    // checks if given test has failed.
+test_print_info(format, args);    // prints formatted message into stdout.
+test_print_error(format, args);   // prints formatted error message into stderr.
+```
 
+example.c
 ``` c
 test(check_failure,{
     ...

--- a/README.md
+++ b/README.md
@@ -7,16 +7,19 @@ Use the `test(TestName, {test code});` macro to add test.
 example.c
 ``` c
 #include "CUnitTests/CUnitTests.h"
-test(First, { printf("From test 1"); });
+test(First, { 
+  printf("From test 1"); }
+);
 ```
 
 ## Tests executable usage
 ```
-program_name -e                   - execute all tests \
-program_name -ei                  - execute all tests in isolation \
-program_name -e first second ...  - execute specified tests \
-program_name -ei first second ... - execute specified tests in isolation\
-program_name                      - list all tests
+test_executable -e                       - execute all tests
+test_executable -ei                      - execute all tests as separate processes
+test_executable -e first second ...      - execute selected tests
+test_executable -ei first second ...     - execute selected tests as separate processes
+test_executable -l                       - list all tests
+test_executable                          - print usage
 
 Additional flags:
 -c                          - color output
@@ -57,8 +60,8 @@ test_assert_not_null_fmt(value, message,...);
 ```
 Seting given test result from code:
 ``` c
-test_set_succeed();    // changes current test result to Succeed.
-test_set_failed();     // changes current test result to Failed. 
+test_set_succeed();    // changes current test result to SUCCEED.
+test_set_failed();     // changes current test result to FAILED. 
 ```
 Additional macros:
 ``` c

--- a/README.md
+++ b/README.md
@@ -39,8 +39,20 @@ test_assert_not_null(value, message,...);
 ```
 Use following macros to set given test result:
 ``` c
-test_succeed(); //set current test result to Succeed.
-test_failed();  //set current test result to Failed. 
+test_set_succeed(); //set current test result to Succeed.
+test_set_failed();  //set current test result to Failed. 
+```
+Use 'test_failed()' to check if test failed
+
+``` c
+test(check_failure,{
+    ...
+    test_assert_true(0, "Should be true");
+    if(test_failed()){
+        return;
+    }
+    ...
+});
 ```
 
 ## CMake installation

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use following macros to set given test result:
 test_set_succeed(); //set current test result to Succeed.
 test_set_failed();  //set current test result to Failed. 
 ```
-Use 'test_failed()' to check if test failed
+Use `test_failed()` to check if test has failed
 
 ``` c
 test(check_failure,{

--- a/README.md
+++ b/README.md
@@ -37,12 +37,23 @@ The test program exit codes:
 ## API
 Build-in test assertions: 
 ``` c
-test_assert_true(expr, message, ...);				
-test_assert_false(expr, message, ...);				
-test_assert_equal(expected, result, message, ...);	
-test_assert_not_equal(expected, result, message, ...);
-test_assert_null(value, message, ...);
-test_assert_not_null(value, message,...);
+test_assert_true(expr);
+test_assert_true_fmt(expr, message, ...);
+
+test_assert_false(expr);								
+test_assert_false_fmt(expr, message, ...);				
+
+test_assert_equal(expected, result);	
+test_assert_equal_fmt(expected, result, message, ...);	
+
+test_assert_not_equal(expected, result);
+test_assert_not_equal_fmt(expected, result, message, ...);
+
+test_assert_null(value, message);
+test_assert_null_fmt(value, message, ...);
+
+test_assert_not_null(value);
+test_assert_not_null_fmt(value, message,...);
 ```
 Seting given test result from code:
 ``` c

--- a/include/CUnitTests/CUnitTests.h
+++ b/include/CUnitTests/CUnitTests.h
@@ -340,22 +340,40 @@ static void __CUnitTests_assertionFailed(char *file, int line, char *message, ..
 #define test_set_succeed() __CUnitTests_setTestSucceed(__FILE__, __LINE__)
 #define test_failed() __CUnitTests_Global_currentTest->result == __CUnitTests_Error_Failed
 
-#define test_assert_true(expr, message, ...)                                                                           \
+#define test_assert_true(expr)                                                                           \
+	if (!(expr)) __CUnitTests_assertionFailed(__FILE__, __LINE__, #expr)
+
+#define test_assert_true_fmt(expr, message, ...)                                                                           \
 	if (!(expr)) __CUnitTests_assertionFailed(__FILE__, __LINE__, message, ##__VA_ARGS__)
 
-#define test_assert_false(expr, message, ...)                                                                          \
+#define test_assert_false(expr)                                                                          \
+	if ((expr)) __CUnitTests_assertionFailed(__FILE__, __LINE__, #expr)
+
+#define test_assert_false_fmt(expr, message, ...)                                                                          \
 	if ((expr)) __CUnitTests_assertionFailed(__FILE__, __LINE__, message, ##__VA_ARGS__)
 
-#define test_assert_equal(expected, result, message, ...)                                                              \
+#define test_assert_equal(expected, result)                                                              \
+	if ((expected) != (result)) __CUnitTests_assertionFailed(__FILE__, __LINE__, "%s==%s", #expected, #result);
+
+#define test_assert_equal_fmt(expected, result, message, ...)                                                              \
 	if ((expected) != (result)) __CUnitTests_assertionFailed(__FILE__, __LINE__, message, ##__VA_ARGS__);
 
-#define test_assert_not_equal(expected, result, message, ...)                                                          \
+#define test_assert_not_equal(expected, result )                                                          \
+	if ((expected) == (result)) __CUnitTests_assertionFailed(__FILE__, __LINE__, "%s!=%s", #expected, #result)
+
+#define test_assert_not_equal_fmt(expected, result, message, ...)                                                          \
 	if ((expected) == (result)) __CUnitTests_assertionFailed(__FILE__, __LINE__, message, ##__VA_ARGS__)
 
-#define test_assert_null(value, message, ...)                                                                          \
+#define test_assert_null(value)                                                                          \
+	if ((value) != (NULL)) __CUnitTests_assertionFailed(__FILE__, __LINE__, "%s == NULL", #value)
+
+#define test_assert_null_fmt(value, message, ...)                                                                          \
 	if ((value) != (NULL)) __CUnitTests_assertionFailed(__FILE__, __LINE__, message, ##__VA_ARGS__)
 
-#define test_assert_not_null(value, message, ...)                                                                      \
+#define test_assert_not_null(value)                                                                      \
+	if ((value) == (NULL)) __CUnitTests_assertionFailed(__FILE__, __LINE__, "%s != NULL", #value)
+
+#define test_assert_not_null_fmt(value, message, ...)                                                                      \
 	if ((value) == (NULL)) __CUnitTests_assertionFailed(__FILE__, __LINE__, message, ##__VA_ARGS__)
 
 #endif /* _CUnitTests_CUnitTests_h_ */

--- a/include/CUnitTests/CUnitTests.h
+++ b/include/CUnitTests/CUnitTests.h
@@ -156,6 +156,7 @@ static __CUnitTests_Context *__CUnitTests_createContext(int argc, char *argv[]) 
 static void __CUnitTests_printError(const char *format, ...) {
 	va_list args;
 	va_start(args, format);
+	fprintf(stderr,"\n\t");
 	vfprintf(stderr, format, args);
 	va_end(args);
 }
@@ -163,6 +164,7 @@ static void __CUnitTests_printError(const char *format, ...) {
 static void __CUnitTests_printInfo(const char *format, ...) {
 	va_list args;
 	va_start(args, format);
+	fprintf(stdout,"\n\t");
 	vfprintf(stdout, format, args);
 	va_end(args);
 }

--- a/include/CUnitTests/CUnitTests.h
+++ b/include/CUnitTests/CUnitTests.h
@@ -62,11 +62,11 @@ typedef struct __CUnitTests_Context {
 	__CUnitTests_ExecutionMode executionMode;
 	__CUnitTests_Error executionResult;
 	__CUnitTests_Test *testsToExecute;
-	int testsToExecuteCount;
+	unsigned testsToExecuteCount;
 } __CUnitTests_Context;
 
 static __CUnitTests_Test __CUnitTests_Global_tests[__CUNIT_TESTS_MAX];
-static int __CUnitTests_Global_testsCount = 0;
+static unsigned __CUnitTests_Global_testsCount = 0;
 static __CUnitTests_Test *__CUnitTests_Global_currentTest = NULL;
 
 static char *__CUnitTests_getFileNameFromPath(char *filePath) {
@@ -155,7 +155,7 @@ static __CUnitTests_Context *__CUnitTests_createContext(int argc, char *argv[]) 
 }
 
 static void __CUnitTests_executeTestsInProcess(__CUnitTests_Context *ctx) {
-	for (int testIndex = 0; testIndex < ctx->testsToExecuteCount; testIndex++) {
+	for (unsigned testIndex = 0; testIndex < ctx->testsToExecuteCount; testIndex++) {
 		__CUnitTests_Test *test = &ctx->testsToExecute[testIndex];
 		if (test->result == __CUnitTests_Error_NotExecuted) {
 			test->result = __CUnitTests_Error_Succeed;
@@ -168,7 +168,7 @@ static void __CUnitTests_executeTestsInProcess(__CUnitTests_Context *ctx) {
 }
 
 static void __CUnitTests_executeTestsAsSeparateProcess(__CUnitTests_Context *ctx) {
-	for (int testIndex = 0; testIndex < ctx->testsToExecuteCount; testIndex++) {
+	for (unsigned testIndex = 0; testIndex < ctx->testsToExecuteCount; testIndex++) {
 		__CUnitTests_Test *test = &ctx->testsToExecute[testIndex];
 		if (test->result == __CUnitTests_Error_NotExecuted) {
 			test->result = __CUnitTests_Error_Succeed;
@@ -193,7 +193,7 @@ static void __CUnitTests_getResults(__CUnitTests_Context *ctx) {
 
 	printf("\n\n%s tests execution failures:", __CUnitTests_getFileNameFromPath(ctx->executableName));
 
-	for (size_t testIndex = 0; testIndex < ctx->testsToExecuteCount; testIndex++) {
+	for (unsigned testIndex = 0; testIndex < ctx->testsToExecuteCount; testIndex++) {
 		__CUnitTests_Test *test = &ctx->testsToExecute[testIndex];
 		switch (test->result) {
 			case __CUnitTests_Error_Succeed:
@@ -243,7 +243,7 @@ static void __CUnitTests_listTests(__CUnitTests_Context *ctx) {
 	printf("\n%s                          - list all tests", executableName);
 
 	printf("\nAvailable tests:\n");
-	for (int index = 0; index < __CUnitTests_Global_testsCount; index++) {
+	for (unsigned index = 0; index < __CUnitTests_Global_testsCount; index++) {
 		printf("\n%s", __CUnitTests_Global_tests[index].test_name);
 	}
 
@@ -263,10 +263,10 @@ static __CUnitTests_Error __CUnitTests_performAction(__CUnitTests_Context *ctx) 
 	return ctx->executionResult;
 }
 
-void main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
 	__CUnitTests_Context *ctx = __CUnitTests_createContext(argc, argv);
 	__CUnitTests_Error result = __CUnitTests_performAction(ctx);
-	exit(result);
+	return result;
 }
 
 static void __CUnitTests_setTestSucceed() { __CUnitTests_Global_currentTest->result = __CUnitTests_Error_Succeed; }

--- a/include/CUnitTests/CUnitTests.h
+++ b/include/CUnitTests/CUnitTests.h
@@ -307,18 +307,18 @@ int main(int argc, char *argv[]) {
 	return result;
 }
 
-static void __CUnitTests_setTestSucceed() { 
-	__CUnitTests_printOut("\n\tSetting test result to Succeed.");
+static void __CUnitTests_setTestSucceed(char *file, int line) { 
+	__CUnitTests_printOut("\n\tSetting test result to Succeed in in %s:%d", file, line);
 	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Succeed; 
 }
 
-static void __CUnitTests_setTestFailed() { 
-	__CUnitTests_printOut("\n\tSetting test result to Failed.");
-	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Failed; 
+static void __CUnitTests_setTestFailed(char *file, int line) { 
+	__CUnitTests_printError("\n\tSetting test result to Failed in %s:%d", file, line);
+	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Failed;
 }
 
 static void __CUnitTests_assertionFailed(char *file, int line, char *message, ...) {
-	__CUnitTests_setTestFailed();
+	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Failed;
 	va_list args;
 	va_start(args, message);
 	fprintf(stderr,"\n\tAssertion failed: '");
@@ -337,8 +337,8 @@ static void __CUnitTests_assertionFailed(char *file, int line, char *message, ..
 		__CUnitTests_Global_tests[id].result = __CUnitTests_Error_NotExecuted;                                         \
 	}
 
-#define test_set_failed() __CUnitTests_setTestFailed()
-#define test_set_succeed() __CUnitTests_setTestSucceed()
+#define test_set_failed() __CUnitTests_setTestFailed(__FILE__, __LINE__)
+#define test_set_succeed() __CUnitTests_setTestSucceed(__FILE__, __LINE__)
 #define test_failed() __CUnitTests_Global_currentTest->result == __CUnitTests_Error_Failed
 
 #define test_assert_true(expr, message, ...)                                                                           \

--- a/include/CUnitTests/CUnitTests.h
+++ b/include/CUnitTests/CUnitTests.h
@@ -283,8 +283,8 @@ static void __CUnitTests_assertionFailed(char *file, int line, char *message, ..
 	va_end(args);
 }
 
-#define test(name, code)                                                                                               \
-	void ___CUnitTests_test_routine_##name() { code }                                                                  \
+#define test(name, ...)                                                                                               \
+	void ___CUnitTests_test_routine_##name() { __VA_ARGS__ }                                                                  \
 	__attribute__((constructor)) void ___CUnitTests_register_test_##name() {                                           \
 		int id = __COUNTER__;                                                                                          \
 		__CUnitTests_Global_testsCount++;                                                                              \
@@ -293,9 +293,9 @@ static void __CUnitTests_assertionFailed(char *file, int line, char *message, ..
 		__CUnitTests_Global_tests[id].result = __CUnitTests_Error_NotExecuted;                                         \
 	}
 
-#define test_failed() __CUnitTests_setTestFailed()
-
-#define test_succeed() __CUnitTests_setTestSucceed()
+#define test_set_failed() __CUnitTests_setTestFailed()
+#define test_set_succeed() __CUnitTests_setTestSucceed()
+#define test_failed()  __CUnitTests_Global_currentTest->result == __CUnitTests_Error_Failed
 
 #define test_assert_true(expr, message, ...)                                                                           \
 	if (!(expr)) __CUnitTests_assertionFailed(__FILE__, __LINE__, message, ##__VA_ARGS__)

--- a/include/CUnitTests/CUnitTests.h
+++ b/include/CUnitTests/CUnitTests.h
@@ -307,9 +307,15 @@ int main(int argc, char *argv[]) {
 	return result;
 }
 
-static void __CUnitTests_setTestSucceed() { __CUnitTests_Global_currentTest->result = __CUnitTests_Error_Succeed; }
+static void __CUnitTests_setTestSucceed() { 
+	__CUnitTests_printOut("\n\tSetting test result to Succeed.");
+	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Succeed; 
+}
 
-static void __CUnitTests_setTestFailed() { __CUnitTests_Global_currentTest->result = __CUnitTests_Error_Failed; }
+static void __CUnitTests_setTestFailed() { 
+	__CUnitTests_printOut("\n\tSetting test result to Failed.");
+	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Failed; 
+}
 
 static void __CUnitTests_assertionFailed(char *file, int line, char *message, ...) {
 	__CUnitTests_setTestFailed();

--- a/include/CUnitTests/CUnitTests.h
+++ b/include/CUnitTests/CUnitTests.h
@@ -160,24 +160,26 @@ static void __CUnitTests_printError(const char *format, ...) {
 	va_end(args);
 }
 
-static void __CUnitTests_printOut(const char *format, ...) {
+static void __CUnitTests_printInfo(const char *format, ...) {
 	va_list args;
 	va_start(args, format);
 	vfprintf(stdout, format, args);
 	va_end(args);
 }
 
+#define test_print_info(format, ...) __CUnitTests_printInfo(format, ##__VA_ARGS__)
+#define test_print_error(format, ...) __CUnitTests_printError(format, ##__VA_ARGS__)
 
 static void __CUnitTests_printExecutingMessage(__CUnitTests_Test *test) {
-	__CUnitTests_printOut("\n'%s' started...\t", test->test_name);
+	test_print_info("\n'%s' started...\t", test->test_name);
 }
 
 static void __CUnitTests_printTestResultMessage(__CUnitTests_Test *test) {
 	char *testResultString = __CUnitTests_getTestResultString(test->result);
 	if (test->result == __CUnitTests_Error_Succeed) {
-		__CUnitTests_printOut("\n'%s' %s", test->test_name, testResultString);
+		test_print_info("\n'%s' %s", test->test_name, testResultString);
 	} else {
-		__CUnitTests_printError("\n'%s' %s", test->test_name, testResultString);
+		test_print_error("\n'%s' %s", test->test_name, testResultString);
 	}
 }
 
@@ -234,11 +236,11 @@ static void __CUnitTests_getResults(__CUnitTests_Context *ctx) {
 	}
 
 	if (tests_failed || tests_errored) {
-		__CUnitTests_printError("\n\n%s tests execution failures:", __CUnitTests_getFileNameFromPath(ctx->executableName));
+		test_print_error("\n\n%s tests execution failures:", __CUnitTests_getFileNameFromPath(ctx->executableName));
 		for (unsigned testIndex = 0; testIndex < ctx->testsToExecuteCount; testIndex++) {
 			__CUnitTests_Test *test = &ctx->testsToExecute[testIndex];
 			if (test->result != __CUnitTests_Error_Succeed) {
-				__CUnitTests_printError("\n%s:\t%s", test->test_name, __CUnitTests_getTestResultString(test->result));
+				test_print_error("\n%s:\t%s", test->test_name, __CUnitTests_getTestResultString(test->result));
 			}
 		}
 	}
@@ -252,10 +254,10 @@ static void __CUnitTests_getResults(__CUnitTests_Context *ctx) {
 	}
 
 	if (ctx->executionResult == __CUnitTests_Error_Succeed) {
-		__CUnitTests_printOut("\n\nTotal: %u. Succeed: %u. Failed: %u. Errors: %u \n", ctx->testsToExecuteCount, tests_succeed,
+		test_print_info("\n\nTotal: %u. Succeed: %u. Failed: %u. Errors: %u \n", ctx->testsToExecuteCount, tests_succeed,
 			   tests_failed, tests_errored);
 	}else{
-		__CUnitTests_printError( "\n\nTotal: %u. Succeed: %u. Failed: %u. Errors: %u \n", ctx->testsToExecuteCount, tests_succeed,
+		test_print_error( "\n\nTotal: %u. Succeed: %u. Failed: %u. Errors: %u \n", ctx->testsToExecuteCount, tests_succeed,
 			   tests_failed, tests_errored);
 	}
 }
@@ -273,16 +275,16 @@ static void __CUnitTests_executeTests(__CUnitTests_Context *ctx) {
 static void __CUnitTests_listTests(__CUnitTests_Context *ctx) {
 	char *executableName = __CUnitTests_getFileNameFromPath(ctx->executableName);
 
-	__CUnitTests_printOut( "\n%s usage:", executableName);
-	__CUnitTests_printOut( "\n%s -e                       - execute all tests", executableName);
-	__CUnitTests_printOut( "\n%s -ei                      - execute all tests in isolation", executableName);
-	__CUnitTests_printOut( "\n%s -e first second ...      - execute selected tests", executableName);
-	__CUnitTests_printOut( "\n%s -ei first second ...     - execute selected tests in isolation", executableName);
-	__CUnitTests_printOut( "\n%s                          - list all tests", executableName);
+	test_print_info( "\n%s usage:", executableName);
+	test_print_info( "\n%s -e                       - execute all tests", executableName);
+	test_print_info( "\n%s -ei                      - execute all tests in isolation", executableName);
+	test_print_info( "\n%s -e first second ...      - execute selected tests", executableName);
+	test_print_info( "\n%s -ei first second ...     - execute selected tests in isolation", executableName);
+	test_print_info( "\n%s                          - list all tests", executableName);
 
-	__CUnitTests_printOut("\nAvailable tests:\n");
+	test_print_info("\nAvailable tests:\n");
 	for (unsigned index = 0; index < __CUnitTests_Global_testsCount; index++) {
-		__CUnitTests_printOut("\n%s", __CUnitTests_Global_tests[index].test_name);
+		test_print_info("\n%s", __CUnitTests_Global_tests[index].test_name);
 	}
 
 	ctx->executionResult = __CUnitTests_Error_Succeed;
@@ -308,12 +310,12 @@ int main(int argc, char *argv[]) {
 }
 
 static void __CUnitTests_setTestSucceed(char *file, int line) { 
-	__CUnitTests_printOut("\n\tSetting test result to Succeed in in %s:%d", file, line);
+	test_print_info("\n\tSetting test result to Succeed in in %s:%d", file, line);
 	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Succeed; 
 }
 
 static void __CUnitTests_setTestFailed(char *file, int line) { 
-	__CUnitTests_printError("\n\tSetting test result to Failed in %s:%d", file, line);
+	test_print_error("\n\tSetting test result to Failed in %s:%d", file, line);
 	__CUnitTests_Global_currentTest->result = __CUnitTests_Error_Failed;
 }
 

--- a/tests/asserts.c
+++ b/tests/asserts.c
@@ -35,12 +35,12 @@ static void error_should_be(__CUnitTests_Error error){
 test(assert_true_success,{
     test_assert_true(1, "Should be true");
     error_should_be(__CUnitTests_Error_Succeed);
-});
+})
 
 test(assert_true_failure,{
     test_assert_true(0, "Should be true");
     error_should_be(__CUnitTests_Error_Failed);
-});
+})
 
 test(assert_check_failure,{
     test_assert_true(0, "Should be true");
@@ -50,66 +50,66 @@ test(assert_check_failure,{
     }else{
          test_set_failed();
     }
-});
+})
 
 test(assert_false_success,{
     test_assert_false(0, "Should be false");
     error_should_be(__CUnitTests_Error_Succeed);
-});
+})
 
 test(assert_false_failure,{
     test_assert_false(1, "Should be false");
     error_should_be(__CUnitTests_Error_Failed);
-});
+})
 
 test(assert_equal_success,{
  	int first = 1;
  	int second = 1;
     test_assert_equal(first, second, "Should be %d but was %d", first, second);
     error_should_be(__CUnitTests_Error_Succeed);
-});
+})
 
 test(assert_equal_failure,{
     int first = 1;
  	int second = 2;
     test_assert_equal(first, second, "Should be %d but was %d", first, second);
     error_should_be(__CUnitTests_Error_Failed);
-});
+})
 
 test(assert_not_equal_success,{
  	int first = 2;
  	int second = 1;
     test_assert_not_equal(first, second, "Should not be %d but was %d", first, second);
     error_should_be(__CUnitTests_Error_Succeed);
-});
+})
 
 test(assert_not_equal_failure,{
     int first = 1;
  	int second = 1;
     test_assert_not_equal(first, second, "Should not be %d but was %d", first, second);
     error_should_be(__CUnitTests_Error_Failed);
-});
+})
 
 test(assert_null_success,{
  	char *test = NULL;
     test_assert_null(test, "Should be null");
     error_should_be(__CUnitTests_Error_Succeed);
-});
+})
 
 test(assert_null_failure,{
     char *test = "Something";
     test_assert_null(test, "Should be null");
     error_should_be(__CUnitTests_Error_Failed);
-});
+})
 
 test(assert_not_null_success,{
  	char *test = "Something";
     test_assert_not_null(test, "Should not be null");
     error_should_be(__CUnitTests_Error_Succeed);
-});
+})
 
 test(assert_not_null_failure,{
     char *test = NULL;
     test_assert_not_null(test, "Should not be null");
     error_should_be(__CUnitTests_Error_Failed);
-});
+})

--- a/tests/asserts.c
+++ b/tests/asserts.c
@@ -26,9 +26,9 @@ SOFTWARE.
 
 static void error_should_be(__CUnitTests_Error error){
     if(__CUnitTests_Global_currentTest->result != error){
-        test_failed();
+        test_set_failed();
     }else{
-        test_succeed();
+        test_set_succeed();
     }
 }
 
@@ -40,6 +40,16 @@ test(assert_true_success,{
 test(assert_true_failure,{
     test_assert_true(0, "Should be true");
     error_should_be(__CUnitTests_Error_Failed);
+});
+
+test(assert_check_failure,{
+    test_assert_true(0, "Should be true");
+
+    if(test_failed()){
+        test_set_succeed();
+    }else{
+         test_set_failed();
+    }
 });
 
 test(assert_false_success,{

--- a/tests/asserts.c
+++ b/tests/asserts.c
@@ -32,18 +32,43 @@ static void error_should_be(__CUnitTests_Error error){
     }
 }
 
-test(assert_true_success,{
-    test_assert_true(1, "Should be true");
+test(test_assert_true_success,{
+    test_assert_true(1);
     error_should_be(__CUnitTests_Error_Succeed);
 })
 
-test(assert_true_failure,{
-    test_assert_true(0, "Should be true");
+test(test_assert_true_success_2,{
+    int first = 1;
+    int second = 1;
+    test_assert_true(first==second);
+    error_should_be(__CUnitTests_Error_Succeed);
+})
+
+test(test_assert_true_fmt_success,{
+    test_assert_true_fmt(1, "Should be true");
+    error_should_be(__CUnitTests_Error_Succeed);
+})
+
+
+test(test_assert_true_failure,{
+    test_assert_true(0);
     error_should_be(__CUnitTests_Error_Failed);
 })
 
-test(assert_check_failure,{
-    test_assert_true(0, "Should be true");
+test(test_assert_true_failure_2,{
+    int first = 1;
+    int second = 2;
+    test_assert_true(first==second);
+    error_should_be(__CUnitTests_Error_Failed);
+})
+
+test(test_assert_true_fmt_failure,{
+    test_assert_true_fmt(0, "Should be true");
+    error_should_be(__CUnitTests_Error_Failed);
+})
+
+test(test_failed_check,{
+    test_assert_true(0);
 
     if(test_failed()){
         test_set_succeed();
@@ -52,64 +77,137 @@ test(assert_check_failure,{
     }
 })
 
-test(assert_false_success,{
-    test_assert_false(0, "Should be false");
+test(test_failed_check_fmt,{
+    test_assert_true_fmt(0, "Should be true");
+
+    if(test_failed()){
+        test_set_succeed();
+    }else{
+         test_set_failed();
+    }
+})
+
+test(test_assert_false_success,{
+    test_assert_false(0);
     error_should_be(__CUnitTests_Error_Succeed);
 })
 
-test(assert_false_failure,{
-    test_assert_false(1, "Should be false");
+test(test_assert_false_fmt_success,{
+    test_assert_false_fmt(0, "Should be false");
+    error_should_be(__CUnitTests_Error_Succeed);
+})
+
+test(test_assert_false_failure,{
+    test_assert_false(1);
     error_should_be(__CUnitTests_Error_Failed);
 })
 
-test(assert_equal_success,{
+
+test(test_assert_false_fmt_failure,{
+    test_assert_false_fmt(1, "Should be false");
+    error_should_be(__CUnitTests_Error_Failed);
+})
+
+test(test_assert_equal_success,{
  	int first = 1;
  	int second = 1;
-    test_assert_equal(first, second, "Should be %d but was %d", first, second);
+    test_assert_equal(first, second);
     error_should_be(__CUnitTests_Error_Succeed);
 })
 
-test(assert_equal_failure,{
+test(test_assert_equal_fmt_success,{
+ 	int first = 1;
+ 	int second = 1;
+    test_assert_equal_fmt(first, second, "Should be %d but was %d", first, second);
+    error_should_be(__CUnitTests_Error_Succeed);
+})
+
+test(test_assert_equal_failure,{
     int first = 1;
  	int second = 2;
-    test_assert_equal(first, second, "Should be %d but was %d", first, second);
+    test_assert_equal(first, second);
     error_should_be(__CUnitTests_Error_Failed);
 })
 
-test(assert_not_equal_success,{
+test(test_assert_equal_fmt_failure,{
+    int first = 1;
+ 	int second = 2;
+    test_assert_equal_fmt(first, second, "Should be %d but was %d", first, second);
+    error_should_be(__CUnitTests_Error_Failed);
+})
+
+test(test_assert_not_equal_success,{
  	int first = 2;
  	int second = 1;
-    test_assert_not_equal(first, second, "Should not be %d but was %d", first, second);
+    test_assert_not_equal(first, second);
     error_should_be(__CUnitTests_Error_Succeed);
 })
 
-test(assert_not_equal_failure,{
+test(test_assert_not_equal_fmt_success,{
+ 	int first = 2;
+ 	int second = 1;
+    test_assert_not_equal_fmt(first, second, "Should not be %d but was %d", first, second);
+    error_should_be(__CUnitTests_Error_Succeed);
+})
+
+test(test_assert_not_equal_failure,{
     int first = 1;
  	int second = 1;
-    test_assert_not_equal(first, second, "Should not be %d but was %d", first, second);
+    test_assert_not_equal(first, second);
     error_should_be(__CUnitTests_Error_Failed);
 })
 
-test(assert_null_success,{
+test(test_assert_not_equal_fmt_failure,{
+    int first = 1;
+ 	int second = 1;
+    test_assert_not_equal_fmt(first, second, "Should not be %d but was %d", first, second);
+    error_should_be(__CUnitTests_Error_Failed);
+})
+
+test(test_assert_null_success,{
  	char *test = NULL;
-    test_assert_null(test, "Should be null");
+    test_assert_null(test);
     error_should_be(__CUnitTests_Error_Succeed);
 })
 
-test(assert_null_failure,{
+test(test_assert_null_fmt_success,{
+ 	char *test = NULL;
+    test_assert_null_fmt(test, "Should be null");
+    error_should_be(__CUnitTests_Error_Succeed);
+})
+
+test(test_assert_null_failure,{
     char *test = "Something";
-    test_assert_null(test, "Should be null");
+    test_assert_null(test);
     error_should_be(__CUnitTests_Error_Failed);
 })
 
-test(assert_not_null_success,{
+test(test_assert_null_fmt_failure,{
+    char *test = "Something";
+    test_assert_null_fmt(test, "Should be null");
+    error_should_be(__CUnitTests_Error_Failed);
+})
+
+test(test_assert_not_null_success,{
  	char *test = "Something";
-    test_assert_not_null(test, "Should not be null");
+    test_assert_not_null(test);
     error_should_be(__CUnitTests_Error_Succeed);
 })
 
-test(assert_not_null_failure,{
+test(test_assert_not_null_fmt_success,{
+ 	char *test = "Something";
+    test_assert_not_null_fmt(test, "Should not be null");
+    error_should_be(__CUnitTests_Error_Succeed);
+})
+
+test(test_assert_not_null_failure,{
     char *test = NULL;
-    test_assert_not_null(test, "Should not be null");
+    test_assert_not_null(test);
+    error_should_be(__CUnitTests_Error_Failed);
+})
+
+test(test_assert_not_null_fmt_failure,{
+    char *test = NULL;
+    test_assert_not_null_fmt(test, "Should not be null");
     error_should_be(__CUnitTests_Error_Failed);
 })

--- a/tests/asserts.c
+++ b/tests/asserts.c
@@ -39,7 +39,7 @@ test(test_assert_true_success,{
 
 test(test_assert_true_success_2,{
     int first = 1;
-    int second = 1;
+    int second = 2;
     test_assert_true(first==second);
     error_should_be(__CUnitTests_Error_Succeed);
 })

--- a/tests/example.c
+++ b/tests/example.c
@@ -26,5 +26,5 @@ SOFTWARE.
 #include "asserts.c"
 #include "test_macro.c"
 
-test(First, { printf("From test 1"); });
-test(Second, { printf("From test 2"); });
+test(First, { printf("From test 1"); })
+test(Second, { printf("From test 2"); })

--- a/tests/test_macro.c
+++ b/tests/test_macro.c
@@ -31,4 +31,4 @@ test(CheckCompiler, {
     for(int i =0; i<2;i++){
         printf("%c",singleQuotes[i]);
     };
-});
+})

--- a/tests/test_macro.c
+++ b/tests/test_macro.c
@@ -23,8 +23,12 @@ SOFTWARE.
 */
 
 #include "CUnitTests/CUnitTests.h"
-#include "asserts.c"
-#include "test_macro.c"
 
-test(First, { printf("From test 1"); });
-test(Second, { printf("From test 2"); });
+test(CheckCompiler, {
+    printf("Double \"quotes\"");
+
+    char singleQuotes[2]={'a', 'b'};
+    for(int i =0; i<2;i++){
+        printf("%c",singleQuotes[i]);
+    };
+});


### PR DESCRIPTION
- [#7] New -q (quiet mode) flag 
- [#8] New -l flag for listing tests
- [#3] test_assert_* functions should not require formatting
- [#4] Colored ouput
- [#6] Add test program result
- [#5] To many new line brakes in output
- printing to stdout, stderr
- output formatting
- change test_failed() and test_succeed() to test_set_failed() and test_set_succeed()
- adding test_failed() check